### PR TITLE
support for 4:3 sizes and better artwork display

### DIFF
--- a/player.css
+++ b/player.css
@@ -90,6 +90,7 @@ body {
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+  object-fit: fill;
 }
 
 .player .media-info {
@@ -98,8 +99,8 @@ body {
 }
 
 .player .media-artwork {
-  background-size: cover;
-  background-position: bottom;
+  background-size: contain;
+  background-position: center;
   background-repeat: no-repeat;
   align-self: flex-end;
   height: 143px;


### PR DESCRIPTION
- this line `object-fit: fill` allows video tag to fill whole screen without break of aspect ratio. that is a key part
- `background-size: contain;
  background-position: center;` this makes artworks more prettier, because some of the logos are square and etc.