### PR TITLE
correcting naming of debug flag

### DIFF
--- a/player.js
+++ b/player.js
@@ -79,7 +79,7 @@ sampleplayer.CastPlayer = function(element) {
    * The debug setting to control receiver, MPL and player logging.
    * @private {boolean}
    */
-  this.debug_ = sampleplayer.DISABLE_DEBUG_;
+  this.debug_ = sampleplayer.ENABLE_DEBUG_;
   if (this.debug_) {
     cast.player.api.setLoggerLevel(cast.player.api.LoggerLevel.DEBUG);
     cast.receiver.logger.setLevelValue(cast.receiver.LoggerLevel.DEBUG);
@@ -432,13 +432,6 @@ sampleplayer.TRANSITION_DURATION_ = 1.5;
  */
 sampleplayer.ENABLE_DEBUG_ = true;
 
-
-/**
- * Const to disable debugging.
- *
- * #@const @private {boolean}
- */
-sampleplayer.DISABLE_DEBUG_ = false;
 
 
 /**


### PR DESCRIPTION
DISABLE_DEBUG_ was incorrectly named, as its value needed to be false for debugging to be enabled; since there is already a "ENABLE_DEBUG_" flag which is unused and serves the same purpose, the code can do without the DISABLE_DEBUG_ flag.